### PR TITLE
add tmp_dir config option

### DIFF
--- a/gxjobconfinit/generate.py
+++ b/gxjobconfinit/generate.py
@@ -85,6 +85,9 @@ K8S_ENVIRONMENT_TEMPLATE = """
 
 
 COMMON_ENVIRONMENT_TEMPLATE = """
+{%- if tmp_dir %}
+tmp_dir: true
+{%- endif %}
 {%- if docker_config.enabled %}
 docker_enabled: true
 {%- if docker_config.sudo %}
@@ -281,11 +284,13 @@ def build_job_config(
     dev_context = dev_context or DevelopmentContext(None, [])
     runner = config.runner
     tpv = config.tpv
+    tmp_dir = config.tmp_dir
     galaxy_version = config.galaxy_version or "25.0"
     docker_config = to_docker_config(dev_context, config)
     singularity_config = to_singularity_config(dev_context, config)
     environment_docker_stuff = render(
         COMMON_ENVIRONMENT_TEMPLATE,
+        tmp_dir=tmp_dir,
         docker_config=docker_config,
         singularity_config=singularity_config,
     )

--- a/gxjobconfinit/types.py
+++ b/gxjobconfinit/types.py
@@ -41,6 +41,7 @@ class CliConfigArgs(TypedDict, total=False):
     singularity_sudo: NotRequired[Optional[bool]]
     singularity_sudo_cmd: NotRequired[Optional[str]]
     singularity_extra_volume: NotRequired[Optional[List[str]]]
+    tmp_dir: NotRequired[bool]
 
 
 @dataclass
@@ -60,6 +61,7 @@ class ConfigArgs:
     singularity_sudo: Optional[bool] = None
     singularity_sudo_cmd: Optional[str] = None
     singularity_extra_volume: Optional[List[str]] = None
+    tmp_dir: Optional[bool] = None
 
     @staticmethod
     def from_dict(**data: Unpack[CliConfigArgs]) -> "ConfigArgs":
@@ -79,4 +81,5 @@ class ConfigArgs:
             singularity_sudo=data.get("singularity_sudo", None),
             singularity_sudo_cmd=data.get("singularity_sudo_cmd", None),
             singularity_extra_volume=data.get("singularity_extra_volume", []),
+            tmp_dir=data.get("tmp_dir", []),
         )

--- a/gxjobconfinit/types.py
+++ b/gxjobconfinit/types.py
@@ -81,5 +81,5 @@ class ConfigArgs:
             singularity_sudo=data.get("singularity_sudo", None),
             singularity_sudo_cmd=data.get("singularity_sudo_cmd", None),
             singularity_extra_volume=data.get("singularity_extra_volume", []),
-            tmp_dir=data.get("tmp_dir", []),
+            tmp_dir=data.get("tmp_dir", True),
         )

--- a/tests/gxjobconfinit/test_job_config.py
+++ b/tests/gxjobconfinit/test_job_config.py
@@ -57,6 +57,16 @@ def test_build_job_config_slurm_with_singularity_and_sudo():
     assert slurm_env["singularity_sudo"] is True
 
 
+def test_build_job_config_slurm_with_tmp_dir():
+    config_dict = build_to_yaml(
+        runner=Runner.SLURM, singularity=True, tmp_dir=True
+    )
+    slurm_env = config_dict["execution"]["environments"]["slurm"]
+    assert slurm_env
+    assert slurm_env["runner"] == "slurm"
+    assert slurm_env["tmp_dir"] is True
+
+
 def test_build_job_config_drmaa():
     config_dict = build_to_yaml(runner=Runner.DRMAA)
     drmaa_env = config_dict["execution"]["environments"]["drmaa"]


### PR DESCRIPTION
This pull-request should handle @mvdbeek request for planemo pull-request [#1506](https://github.com/galaxyproject/planemo/pull/1506)

```
Could we also default to tmp_dir: true on the destination (i.e tmpdir in work dir) ? I think that's the easiest way to get something that will most likely work ?
```