### PR TITLE
Add all in one config option

### DIFF
--- a/gxjobconfinit/arg_parsing.py
+++ b/gxjobconfinit/arg_parsing.py
@@ -23,6 +23,8 @@ HELP_SINGULARITY_CMD = "Command used to execute singularity (defaults to 'singul
 HELP_SINGULARITY_SUDO = "Use sudo with Singularity."
 HELP_SINGULARITY_SUDO_CMD = "Singularity sudo command."
 HELP_SINGULARITY_EXTRA_VOLUME = "Extra Singularity volumes."
+HELP_TMP_DIR = "Configure temporary directory handling. Use 'true' for Galaxy-managed temp dirs, or specify shell commands/variables for custom temp directory allocation (e.g., '$DRM_VAR' or '$(mktemp -d /scratch/gxyXXXXXX)'). Defaults to true."
+HELP_ALL_IN_ONE_HANDLING = "Use all-in-one job handling configuration. No separate processes are required to handle jobs or workflows. Recommended for temporary or single user Galaxy instances such as created by planemo."
 
 
 def config_args(argv: List[str]):
@@ -44,6 +46,8 @@ def config_args(argv: List[str]):
         singularity_sudo=args.singularity_sudo,
         singularity_sudo_cmd=args.singularity_sudo_cmd,
         singularity_extra_volume=args.singularity_extra_volume,
+        tmp_dir=args.tmp_dir,
+        all_in_one_handling=args.all_in_one_handling,
     )
     return config_args
 
@@ -70,4 +74,6 @@ def argparser() -> argparse.ArgumentParser:
         nargs="*",
         help=HELP_SINGULARITY_EXTRA_VOLUME,
     )
+    parser.add_argument("--tmp-dir", type=str, default="true", help=HELP_TMP_DIR)
+    parser.add_argument("--all-in-one-handling", action="store_true", help=HELP_ALL_IN_ONE_HANDLING)
     return parser

--- a/gxjobconfinit/types.py
+++ b/gxjobconfinit/types.py
@@ -41,7 +41,8 @@ class CliConfigArgs(TypedDict, total=False):
     singularity_sudo: NotRequired[Optional[bool]]
     singularity_sudo_cmd: NotRequired[Optional[str]]
     singularity_extra_volume: NotRequired[Optional[List[str]]]
-    tmp_dir: NotRequired[bool]
+    tmp_dir: NotRequired[Optional[str]]
+    all_in_one_handling: NotRequired[bool]
 
 
 @dataclass
@@ -61,7 +62,8 @@ class ConfigArgs:
     singularity_sudo: Optional[bool] = None
     singularity_sudo_cmd: Optional[str] = None
     singularity_extra_volume: Optional[List[str]] = None
-    tmp_dir: Optional[bool] = None
+    tmp_dir: Optional[str] = None
+    all_in_one_handling: Optional[bool] = False
 
     @staticmethod
     def from_dict(**data: Unpack[CliConfigArgs]) -> "ConfigArgs":
@@ -81,5 +83,6 @@ class ConfigArgs:
             singularity_sudo=data.get("singularity_sudo", None),
             singularity_sudo_cmd=data.get("singularity_sudo_cmd", None),
             singularity_extra_volume=data.get("singularity_extra_volume", []),
-            tmp_dir=data.get("tmp_dir", True),
+            tmp_dir=data.get("tmp_dir", "true"),
+            all_in_one_handling=data.get("all_in_one_handling", False),
         )

--- a/tests/gxjobconfinit/test_job_config.py
+++ b/tests/gxjobconfinit/test_job_config.py
@@ -56,7 +56,7 @@ def test_build_job_config_slurm_with_singularity_and_sudo():
 
 
 def test_build_job_config_slurm_with_tmp_dir():
-    config_dict = build_to_yaml(runner=Runner.SLURM, singularity=True, tmp_dir=True)
+    config_dict = build_to_yaml(runner=Runner.SLURM, singularity=True, tmp_dir="true")
     slurm_env = config_dict["execution"]["environments"]["slurm"]
     assert slurm_env
     assert slurm_env["runner"] == "slurm"
@@ -107,6 +107,70 @@ def test_build_job_config_slurm_tpv_legacy():
 
     tpv_env = config_dict["execution"]["environments"]["tpv"]
     assert tpv_env["runner"] == "dynamic"
+
+
+def test_tmp_dir_default():
+    """Test that tmp_dir defaults to true and is included."""
+    config_dict = build_to_yaml(runner=Runner.LOCAL)
+    local_env = config_dict["execution"]["environments"]["local"]
+    assert local_env["tmp_dir"] is True
+
+
+def test_tmp_dir_true():
+    """Test tmp_dir with explicit 'true' string value."""
+    config_dict = build_to_yaml(runner=Runner.LOCAL, tmp_dir="true")
+    local_env = config_dict["execution"]["environments"]["local"]
+    assert local_env["tmp_dir"] is True
+
+
+def test_tmp_dir_false():
+    """Test tmp_dir with 'false' string value is omitted."""
+    config_dict = build_to_yaml(runner=Runner.LOCAL, tmp_dir="false")
+    local_env = config_dict["execution"]["environments"]["local"]
+    assert "tmp_dir" not in local_env
+
+
+def test_tmp_dir_variable():
+    """Test tmp_dir with environment variable."""
+    config_dict = build_to_yaml(runner=Runner.LOCAL, tmp_dir="$DRM_JOB_TMP_DIR")
+    local_env = config_dict["execution"]["environments"]["local"]
+    assert local_env["tmp_dir"] == "$DRM_JOB_TMP_DIR"
+
+
+def test_tmp_dir_shell_command():
+    """Test tmp_dir with shell command."""
+    shell_cmd = "$(mktemp -d /scratch/gxyXXXXXX)"
+    config_dict = build_to_yaml(runner=Runner.LOCAL, tmp_dir=shell_cmd)
+    local_env = config_dict["execution"]["environments"]["local"]
+    assert local_env["tmp_dir"] == shell_cmd
+
+
+def test_all_in_one_handling_disabled():
+    """Test that normal handling section is included by default."""
+    config_dict = build_to_yaml(runner=Runner.LOCAL, all_in_one_handling=False)
+    assert "handling" in config_dict
+    assert config_dict["handling"]["assign"] == ["db-skip-locked"]
+
+
+def test_all_in_one_handling_enabled():
+    """Test that handling section is omitted with all_in_one_handling=True."""
+    config_dict = build_to_yaml(runner=Runner.LOCAL, all_in_one_handling=True)
+    assert "handling" not in config_dict
+
+
+def test_all_in_one_handling_with_slurm():
+    """Test all_in_one_handling works with different runners."""
+    config_dict = build_to_yaml(runner=Runner.SLURM, all_in_one_handling=True)
+    assert "handling" not in config_dict
+    assert config_dict["execution"]["default"] == "slurm"
+
+
+def test_tmp_dir_and_all_in_one_combined():
+    """Test that both options can be used together."""
+    config_dict = build_to_yaml(runner=Runner.LOCAL, tmp_dir="$CUSTOM_TMP", all_in_one_handling=True)
+    assert "handling" not in config_dict
+    local_env = config_dict["execution"]["environments"]["local"]
+    assert local_env["tmp_dir"] == "$CUSTOM_TMP"
 
 
 def test_summary():


### PR DESCRIPTION
Planemo doesn't set up job handler processes, so if you include
```
handling:
  assign:
    - db-skip-locked
```
it'll just never run any jobs.