### PR TITLE
Add ``--local-workers`` option to specify LocalJobRunner workers

### DIFF
--- a/gxjobconfinit/arg_parsing.py
+++ b/gxjobconfinit/arg_parsing.py
@@ -23,6 +23,7 @@ HELP_SINGULARITY_CMD = "Command used to execute singularity (defaults to 'singul
 HELP_SINGULARITY_SUDO = "Use sudo with Singularity."
 HELP_SINGULARITY_SUDO_CMD = "Singularity sudo command."
 HELP_SINGULARITY_EXTRA_VOLUME = "Extra Singularity volumes."
+HELP_LOCAL_WORKERS = "Number of worker threads for the LocalJobRunner."
 HELP_TMP_DIR = "Configure temporary directory handling. Use 'true' for Galaxy-managed temp dirs, or specify shell commands/variables for custom temp directory allocation (e.g., '$DRM_VAR' or '$(mktemp -d /scratch/gxyXXXXXX)'). Defaults to true."
 HELP_ALL_IN_ONE_HANDLING = "Use all-in-one job handling configuration. No separate processes are required to handle jobs or workflows. Recommended for temporary or single user Galaxy instances such as created by planemo."
 
@@ -46,6 +47,7 @@ def config_args(argv: List[str]):
         singularity_sudo=args.singularity_sudo,
         singularity_sudo_cmd=args.singularity_sudo_cmd,
         singularity_extra_volume=args.singularity_extra_volume,
+        local_workers=args.local_workers,
         tmp_dir=args.tmp_dir,
         all_in_one_handling=args.all_in_one_handling,
     )
@@ -74,6 +76,7 @@ def argparser() -> argparse.ArgumentParser:
         nargs="*",
         help=HELP_SINGULARITY_EXTRA_VOLUME,
     )
+    parser.add_argument("--local-workers", type=int, help=HELP_LOCAL_WORKERS)
     parser.add_argument("--tmp-dir", type=str, default="true", help=HELP_TMP_DIR)
     parser.add_argument("--all-in-one-handling", action="store_true", help=HELP_ALL_IN_ONE_HANDLING)
     return parser

--- a/gxjobconfinit/generate.py
+++ b/gxjobconfinit/generate.py
@@ -22,8 +22,12 @@ TEMPLATE = """
 runners:
   local:
     load: galaxy.jobs.runners.local:LocalJobRunner
+{%- if local_workers %}
+    workers: {{ local_workers }}
+{%- else %}
     # modify the number of threads working on local jobs here
     # workers: 4
+{%- endif %}
 {{ additional_runners }}
 {{ handling_config}}
 
@@ -352,6 +356,7 @@ def build_job_config(
         local_environment=local_environment,
         default_environment=default_environment,
         handling_config=handling_config,
+        local_workers=config.local_workers,
     )
     yaml.safe_load(config_str)  # try loading it just to assure we're building valid YAML
     return config_str

--- a/gxjobconfinit/types.py
+++ b/gxjobconfinit/types.py
@@ -41,6 +41,7 @@ class CliConfigArgs(TypedDict, total=False):
     singularity_sudo: NotRequired[Optional[bool]]
     singularity_sudo_cmd: NotRequired[Optional[str]]
     singularity_extra_volume: NotRequired[Optional[List[str]]]
+    local_workers: NotRequired[Optional[int]]
     tmp_dir: NotRequired[Optional[str]]
     all_in_one_handling: NotRequired[bool]
 
@@ -62,6 +63,7 @@ class ConfigArgs:
     singularity_sudo: Optional[bool] = None
     singularity_sudo_cmd: Optional[str] = None
     singularity_extra_volume: Optional[List[str]] = None
+    local_workers: Optional[int] = None
     tmp_dir: Optional[str] = None
     all_in_one_handling: Optional[bool] = False
 
@@ -83,6 +85,7 @@ class ConfigArgs:
             singularity_sudo=data.get("singularity_sudo", None),
             singularity_sudo_cmd=data.get("singularity_sudo_cmd", None),
             singularity_extra_volume=data.get("singularity_extra_volume", []),
+            local_workers=data.get("local_workers", None),
             tmp_dir=data.get("tmp_dir", "true"),
             all_in_one_handling=data.get("all_in_one_handling", False),
         )

--- a/tests/gxjobconfinit/test_job_config.py
+++ b/tests/gxjobconfinit/test_job_config.py
@@ -173,6 +173,30 @@ def test_tmp_dir_and_all_in_one_combined():
     assert local_env["tmp_dir"] == "$CUSTOM_TMP"
 
 
+def test_local_workers_default():
+    """Test that local runner has commented workers by default."""
+    config = ConfigArgs.from_dict()
+    job_config = build_job_config(config)
+    assert "# workers: 4" in job_config
+    config_dict = yaml.safe_load(job_config)
+    local_runner = config_dict["runners"]["local"]
+    assert "workers" not in local_runner
+
+
+def test_local_workers_specified():
+    """Test that local runner workers can be explicitly set."""
+    config_dict = build_to_yaml(local_workers=8)
+    local_runner = config_dict["runners"]["local"]
+    assert local_runner["workers"] == 8
+
+
+def test_local_workers_one():
+    """Test that local runner workers can be set to 1."""
+    config_dict = build_to_yaml(local_workers=1)
+    local_runner = config_dict["runners"]["local"]
+    assert local_runner["workers"] == 1
+
+
 def test_summary():
     print(summary_markdown())
 


### PR DESCRIPTION
Allow explicitly setting the number of worker threads for the LocalJobRunner via --local-workers CLI flag instead of requiring manual edits to the generated YAML.